### PR TITLE
Fixed broken link to license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains an optional component of the Microsoft Computational Ne
 
 Go to the main CNTK repository at https://github.com/Microsoft/CNTK for more information on building and using CNTK with 1bit-SGD functionality.
 
-Note that the 1bit-SGD component is licensed under a license different from the rest of CNTK. See [LICENSE.md](./LICENSE.md) in the root of this repository for full license information.
+Note that the 1bit-SGD component is licensed under a license different from the rest of CNTK. See [LICENSE-GENERAL.md](./LICENSE-GENERAL.md) in the root of this repository for full license information.
 
 For obtaining information on CNTK (including 1bit-SGD) go to the [CNTK documentation](https://docs.microsoft.com/en-us/cognitive-toolkit).


### PR DESCRIPTION
Fixes a broken link referencing the license for CNTK1bitSGD, located on `README.md`